### PR TITLE
Import futures-tls and rename to tokio-tls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: rust
+
+rust:
+  - stable
+  - beta
+  - nightly
+sudo: false
+before_script:
+  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+script:
+  - cargo build
+  - cargo test
+  - cargo doc --no-deps
+after_success:
+  - travis-cargo --only nightly doc-upload
+env:
+  global:
+    - secure: qsl13diqVCpez/Obk5T3EhS3UlKzOYGqFw6AeIeXZhQnBgRD488H9RPp8wxyTFazCVCbRZLLR7q2nTsGDWauEYU9hSm66BkUySqmJEL+eSeXSSUxtbSvATOAMqlceL4uYc6hqjwqrtCmdbrF4dopVg1ZDKGMBMG7TfjvU8NAXr3f+kqYEnJSv1qFGgTFv4itRboAEycRX2omWEpHLCkPvzJhBPFs6F/7SCesrluiKxkREkPjw67IU6uCASCHJ/trIeSc5oWE0jLvIxWR1+sYZHj2QR6j7FnYfSQKPG3mojigQ4kxyhAybDEt+RX4k3ZrR7aikwvwGg1FZB9Sj5QheRYOoN26kj2RTUEs/3vz0VXXQ+iRYSeUPGa/0gcBzhbDvcoKI60Y2tY+DMDqu9aV1k56NJe2O2x9BTwVzgTvSZwvLvMvOmyggFQtvyPVrGhL3lYJ/D5767giaHMBytDRdVfR0RxhuE3RDtXrZbW0DUMGvKuIvm1rFDL10GPV3XaZ7cCmSJu0FoBDd1r0XwVEev4ikmMObUzmXrk3FpDfdfTCqIQxnVnGaVzO54J+Lhpp9ayuABelk+OxUpGCDuPd+rDsbaDq7KAo+jP8BdEbdzNSQhxSo+fd9/KDlFfBHUCLFdM0C9q5OT0iKXM1o5wH+0zl+DiyOBoiA+oUJ10TeiE=
+notifications:
+  email:
+    on_success: never
+os:
+  - linux
+  - osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,45 @@
 [package]
-name = "tokio-ssl"
+name = "tokio-tls"
 version = "0.1.0"
-authors = ["Carl Lerche <me@carllerche.com>"]
+authors = ["Carl Lerche <me@carllerche.com>",
+           "Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT/Apache-2.0"
+repository = "https://github.com/tokio-rs/tokio-tls"
+homepage = "https://github.com/tokio-rs/tokio-tls"
+documentation = "https://tokio-rs.github.io/tokio-tls"
+description = """
+An implementation of TLS/SSL streams for Tokio giving an implementation of TLS
+for nonblocking I/O streams.
+"""
 
 [dependencies]
-tokio = { git = "https://github.com/tokio-rs/tokio" }
-log = "0.3.6"
-openssl = "0.8.0"
+cfg-if = "0.1"
+futures = { git = "https://github.com/alexcrichton/futures-rs" }
+log = "0.3"
+
+# Optional dependency that can be enabled with the `force-openssl` feature
+openssl = { version = "0.8", optional = true }
+openssl-verify = { version = "0.2", optional = true }
+
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+openssl = "0.8"
+openssl-verify = "0.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework = "0.1"
+
+[target.'cfg(windows)'.dependencies]
+schannel = "0.1"
+
+[target.'cfg(windows)'.dev-dependencies]
+advapi32-sys = "0.2"
+crypt32-sys = "0.2"
+kernel32-sys = "0.2"
+winapi = "0.2"
 
 [dev-dependencies]
-env_logger = "0.3.4"
+tokio-core = { git = "https://github.com/tokio-rs/tokio-core" }
+env_logger = "0.3"
+
+[features]
+force-openssl = ["openssl", "openssl-verify"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# Tokio SSL
+# tokio-tls
 
-An implementation of TLS/SSL streams for use with
-[Tokio](https://github.com/tokio-rs/tokio).
+An implementation of TLS/SSL streams for Tokio
 
-**This library is still very experimental**
+[![Build Status](https://travis-ci.org/tokio-rs/tokio-tls.svg?branch=master)](https://travis-ci.org/alexcrichton/tokio-tls)
+[![Build status](https://ci.appveyor.com/api/projects/status/iiut5d2mts6bt5g1?svg=true)](https://ci.appveyor.com/project/alexcrichton/tokio-tls)
+
+[Documentation](http://tokio-rs.com/tokio-tls/futures_tls)
 
 ## Usage
 
@@ -11,19 +13,20 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-tls = { git = "https://github.com/tokio-rs/tokio-ssl" }
+futures-tls = { git = "https://github.com/tokio-rs/tokio-tls" }
 ```
 
 Next, add this to your crate:
 
 ```rust
-extern crate tokio_ssl;
+extern crate futures_tls;
 ```
 
 # License
 
-`futures-tls` is primarily distributed under the terms of both the MIT license
+`tokio-tls` is primarily distributed under the terms of both the MIT license
 and the Apache License (Version 2.0), with portions covered by various BSD-like
 licenses.
 
 See LICENSE-APACHE, and LICENSE-MIT for details.
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+environment:
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo build
+  - cargo test

--- a/src/openssl.rs
+++ b/src/openssl.rs
@@ -1,0 +1,264 @@
+extern crate openssl;
+extern crate openssl_verify;
+extern crate futures;
+
+use std::io::{self, Read, Write, Error, ErrorKind};
+use std::mem;
+
+use self::openssl::crypto::pkey::PKey;
+use self::openssl::ssl::{SSL_OP_NO_SSLV2, SSL_OP_NO_SSLV3, SSL_OP_NO_COMPRESSION};
+use self::openssl::ssl::{self, IntoSsl, SSL_VERIFY_PEER};
+use self::openssl::x509::X509;
+use self::openssl_verify::verify_callback;
+use futures::{Poll, Future};
+
+pub struct ServerContext {
+    inner: ssl::SslContext,
+}
+
+pub struct ClientContext {
+    inner: ssl::SslContext,
+}
+
+fn cx_new() -> io::Result<ssl::SslContext> {
+    let mut cx = try!(ssl::SslContext::new(ssl::SslMethod::Sslv23)
+                          .map_err(translate_ssl));
+
+    // lifted from rust-native-tls
+    cx.set_options(SSL_OP_NO_SSLV2 |
+                   SSL_OP_NO_SSLV3 |
+                   SSL_OP_NO_COMPRESSION);
+    let list = "ALL!EXPORT!EXPORT40!EXPORT56!aNULL!LOW!RC4@STRENGTH";
+    try!(cx.set_cipher_list(list).map_err(translate_ssl));
+
+    Ok(cx)
+}
+
+impl ServerContext {
+    pub fn handshake<S>(self, stream: S) -> ServerHandshake<S>
+        where S: Read + Write,
+    {
+        let res = ssl::SslStream::accept(&self.inner, stream);
+        debug!("server handshake");
+        ServerHandshake {
+            inner: Handshake::new(res),
+        }
+    }
+}
+
+fn stack2handshake<S>(err: openssl::error::ErrorStack) -> ssl::HandshakeError<S> {
+    ssl::HandshakeError::Failure(ssl::error::Error::Ssl(err))
+}
+
+impl ClientContext {
+    pub fn new() -> io::Result<ClientContext> {
+        let mut cx = try!(cx_new());
+        try!(cx.set_default_verify_paths().map_err(translate_ssl));
+        Ok(ClientContext { inner: cx })
+    }
+
+    pub fn handshake<S>(self,
+                        domain: &str,
+                        stream: S) -> ClientHandshake<S>
+        where S: Read + Write,
+    {
+        // see rust-native-tls for the specifics here
+        debug!("client handshake with {:?}", domain);
+        let res = self.inner.into_ssl()
+                      .map_err(stack2handshake)
+                      .and_then(|mut ssl| {
+            try!(ssl.set_hostname(domain).map_err(stack2handshake));
+            let domain = domain.to_owned();
+            ssl.set_verify_callback(SSL_VERIFY_PEER, move |p, x| {
+                verify_callback(&domain, p, x)
+            });
+            ssl::SslStream::connect(ssl, stream)
+        });
+        ClientHandshake { inner: Handshake::new(res) }
+    }
+}
+
+pub struct ClientHandshake<S> {
+    inner: Handshake<S>,
+}
+
+pub struct ServerHandshake<S> {
+    inner: Handshake<S>,
+}
+
+enum Handshake<S> {
+    Error(io::Error),
+    Stream(ssl::SslStream<S>),
+    Interrupted(ssl::MidHandshakeSslStream<S>),
+    Empty,
+}
+
+impl<S> Handshake<S> {
+    fn new(res: Result<ssl::SslStream<S>, ssl::HandshakeError<S>>)
+           -> Handshake<S> {
+        match res {
+            Ok(s) => Handshake::Stream(s),
+            Err(ssl::HandshakeError::Failure(e)) => {
+                Handshake::Error(Error::new(ErrorKind::Other, e))
+            }
+            Err(ssl::HandshakeError::Interrupted(s)) => {
+                Handshake::Interrupted(s)
+            }
+        }
+    }
+}
+
+impl<S> Future for ClientHandshake<S>
+    where S: Read + Write,
+{
+    type Item = TlsStream<S>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<TlsStream<S>, io::Error> {
+        self.inner.poll()
+    }
+}
+
+impl<S> Future for ServerHandshake<S>
+    where S: Read + Write,
+{
+    type Item = TlsStream<S>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<TlsStream<S>, io::Error> {
+        self.inner.poll()
+    }
+}
+
+impl<S> Future for Handshake<S>
+    where S: Read + Write,
+{
+    type Item = TlsStream<S>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<TlsStream<S>, io::Error> {
+        debug!("let's see how the handshake went");
+        let stream = match mem::replace(self, Handshake::Empty) {
+            Handshake::Error(e) => return Poll::Err(e),
+            Handshake::Empty => panic!("can't poll handshake twice"),
+            Handshake::Stream(s) => return Poll::Ok(TlsStream::new(s)),
+            Handshake::Interrupted(s) => s,
+        };
+
+        // TODO: dedup with Handshake::new
+        debug!("openssl handshake again");
+        match stream.handshake() {
+            Ok(s) => Poll::Ok(TlsStream::new(s)),
+            Err(ssl::HandshakeError::Failure(e)) => {
+                debug!("openssl handshake failure: {:?}", e);
+                Poll::Err(Error::new(ErrorKind::Other, e))
+            }
+            Err(ssl::HandshakeError::Interrupted(s)) => {
+                debug!("handshake not completed");
+                *self = Handshake::Interrupted(s);
+                Poll::NotReady
+            }
+        }
+    }
+}
+
+fn translate_ssl(err: openssl::error::ErrorStack) -> Error {
+    Error::new(io::ErrorKind::Other, err)
+}
+
+fn translate(err: openssl::ssl::Error) -> Error {
+    match err {
+        openssl::ssl::Error::WantRead(i) |
+        openssl::ssl::Error::WantWrite(i) => return i,
+        _ => Error::new(io::ErrorKind::Other, err),
+    }
+}
+
+pub struct TlsStream<S> {
+    inner: ssl::SslStream<S>,
+}
+
+impl<S> TlsStream<S> {
+    fn new(s: ssl::SslStream<S>) -> TlsStream<S> {
+        TlsStream {
+            inner: s,
+        }
+    }
+}
+
+impl<S: Read + Write> Read for TlsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.ssl_read(buf).map_err(translate)
+    }
+}
+
+impl<S: Read + Write> Write for TlsStream<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.ssl_write(buf).map_err(translate)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Extension trait for servers backed by OpenSSL.
+pub trait ServerContextExt: Sized {
+    /// Creates a new server context given the public/private key pair.
+    ///
+    /// This will create a new server connection which will send `cert` to
+    /// clients and use `key` as the corresponding private key to encrypt and
+    /// sign communications.
+    fn new(cert: &X509, key: &PKey) -> io::Result<Self>;
+
+    /// Gets a mutable reference to the underlying SSL context, allowing further
+    /// configuration.
+    ///
+    /// The SSL context here will eventually get used to initiate the server
+    /// connection.
+    fn ssl_context_mut(&mut self) -> &mut ssl::SslContext;
+}
+
+impl ServerContextExt for ::ServerContext {
+    fn new(cert: &X509, key: &PKey) -> io::Result<::ServerContext> {
+        let mut cx = try!(cx_new());
+        try!(cx.set_certificate(cert).map_err(translate_ssl));
+        try!(cx.set_private_key(key).map_err(translate_ssl));
+        try!(cx.check_private_key().map_err(translate_ssl));
+        Ok(::ServerContext { inner: ServerContext { inner: cx } })
+    }
+
+    fn ssl_context_mut(&mut self) -> &mut ssl::SslContext {
+        &mut self.inner.inner
+    }
+}
+
+/// Extension trait for clients backed by OpenSSL.
+pub trait ClientContextExt {
+    /// Gets a mutable reference to the underlying SSL context, allowing further
+    /// configuration.
+    ///
+    /// The SSL context here will eventually get used to initiate the client
+    /// connection, and it will otherwise be configured to validate the hostname
+    /// given to `handshake` by default.
+    fn ssl_context_mut(&mut self) -> &mut ssl::SslContext;
+}
+
+impl ClientContextExt for ::ClientContext {
+    fn ssl_context_mut(&mut self) -> &mut ssl::SslContext {
+        &mut self.inner.inner
+    }
+}
+
+/// Extension trait for streams backed by OpenSSL.
+pub trait TlsStreamExt {
+    /// Gets a shared reference to the underlying SSL context, allowing further
+    /// configuration and/or inspection of the SSL/TLS state.
+    fn ssl_context(&self) -> &ssl::Ssl;
+}
+
+impl<S> TlsStreamExt for ::TlsStream<S> {
+    fn ssl_context(&self) -> &ssl::Ssl {
+        self.inner.inner.ssl()
+    }
+}

--- a/src/schannel.rs
+++ b/src/schannel.rs
@@ -1,0 +1,236 @@
+extern crate schannel;
+
+use std::io::{self, Read, Write};
+use std::mem;
+
+use self::schannel::tls_stream::{self, HandshakeError};
+use self::schannel::tls_stream::MidHandshakeTlsStream;
+use self::schannel::schannel_cred::{self, Direction};
+use futures::{Poll, Future};
+
+pub struct ServerContext {
+    cred: schannel_cred::Builder,
+    stream: tls_stream::Builder,
+}
+
+pub struct ClientContext {
+    cred: schannel_cred::Builder,
+    stream: tls_stream::Builder,
+}
+
+impl ServerContext {
+    pub fn handshake<S>(mut self, stream: S) -> ServerHandshake<S>
+        where S: Read + Write,
+    {
+        let res = self.cred.acquire(Direction::Inbound);
+        let res = res.map_err(HandshakeError::Failure);
+        let res = res.and_then(|cred| {
+            self.stream.accept(cred, stream)
+        });
+        ServerHandshake { inner: Handshake::new(res) }
+    }
+}
+
+
+impl ClientContext {
+    pub fn new() -> io::Result<ClientContext> {
+        Ok(ClientContext {
+            cred: schannel_cred::Builder::new(),
+            stream: tls_stream::Builder::new(),
+        })
+    }
+
+    pub fn handshake<S>(mut self,
+                        domain: &str,
+                        stream: S) -> ClientHandshake<S>
+        where S: Read + Write,
+    {
+        let res = self.cred.acquire(Direction::Outbound);
+        let res = res.map_err(HandshakeError::Failure);
+        let res = res.and_then(|cred| {
+            self.stream.domain(domain).connect(cred, stream)
+        });
+        ClientHandshake { inner: Handshake::new(res) }
+    }
+}
+
+pub struct ServerHandshake<S> {
+    inner: Handshake<S>,
+}
+
+pub struct ClientHandshake<S> {
+    inner: Handshake<S>,
+}
+
+enum Handshake<S> {
+    Error(io::Error),
+    Stream(tls_stream::TlsStream<S>),
+    Interrupted(MidHandshakeTlsStream<S>),
+    Empty,
+}
+
+impl<S> Future for ClientHandshake<S>
+    where S: Read + Write,
+{
+    type Item = TlsStream<S>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<TlsStream<S>, io::Error> {
+        self.inner.poll()
+    }
+}
+
+impl<S> Future for ServerHandshake<S>
+    where S: Read + Write,
+{
+    type Item = TlsStream<S>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<TlsStream<S>, io::Error> {
+        self.inner.poll()
+    }
+}
+
+impl<S> Handshake<S> {
+    fn new(res: Result<tls_stream::TlsStream<S>, HandshakeError<S>>)
+           -> Handshake<S> {
+        match res {
+            Ok(s) => Handshake::Stream(s),
+            Err(HandshakeError::Failure(e)) => Handshake::Error(e),
+            Err(HandshakeError::Interrupted(s)) => Handshake::Interrupted(s),
+        }
+    }
+}
+
+impl<S> Future for Handshake<S>
+    where S: Read + Write,
+{
+    type Item = TlsStream<S>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<TlsStream<S>, io::Error> {
+        let stream = match mem::replace(self, Handshake::Empty) {
+            Handshake::Error(e) => return Poll::Err(e),
+            Handshake::Empty => panic!("can't poll handshake twice"),
+            Handshake::Stream(s) => return Poll::Ok(TlsStream::new(s)),
+            Handshake::Interrupted(s) => s,
+        };
+
+        // TODO: dedup with Handshake::new
+        match stream.handshake() {
+            Ok(s) => Poll::Ok(TlsStream::new(s)),
+            Err(HandshakeError::Failure(e)) => Poll::Err(e),
+            Err(HandshakeError::Interrupted(s)) => {
+                *self = Handshake::Interrupted(s);
+                Poll::NotReady
+            }
+        }
+    }
+}
+
+pub struct TlsStream<S> {
+    inner: tls_stream::TlsStream<S>,
+}
+
+impl<S> TlsStream<S> {
+    fn new(s: tls_stream::TlsStream<S>) -> TlsStream<S> {
+        TlsStream { inner: s }
+    }
+}
+
+impl<S: Read + Write> Read for TlsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl<S: Read + Write> Write for TlsStream<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Extension trait for servers backed by SChannel.
+pub trait ServerContextExt: Sized {
+    /// Creates a new server which is ready for configuration via
+    /// `schannel_cred` and `tls_stream`.
+    ///
+    /// Note that accepting connections will likely not work unless a public and
+    /// private key are configured via the `schannel_cred` method.
+    fn new() -> Self;
+
+    /// Gets a mutable reference to the underlying SChannel credential builder,
+    /// allowing further configuration.
+    ///
+    /// The builder here will eventually get used to initiate the client
+    /// connection, and it will otherwise be configured to validate the hostname
+    /// given to `handshake` by default.
+    fn schannel_cred(&mut self) -> &mut schannel_cred::Builder;
+
+    /// Gets a mutable reference to the underlying TLS stream builder, allowing
+    /// further configuration.
+    ///
+    /// The builder here will eventually get used to initiate the client
+    /// connection, and it will otherwise be configured to validate the hostname
+    /// given to `handshake` by default.
+    fn tls_stream(&mut self) -> &mut tls_stream::Builder;
+}
+
+impl ServerContextExt for ::ServerContext {
+    fn new() -> ::ServerContext {
+        ::ServerContext {
+            inner: ServerContext {
+                cred: schannel_cred::Builder::new(),
+                stream: tls_stream::Builder::new(),
+            },
+        }
+    }
+
+    fn schannel_cred(&mut self) -> &mut schannel_cred::Builder {
+        &mut self.inner.cred
+    }
+
+    fn tls_stream(&mut self) -> &mut tls_stream::Builder {
+        &mut self.inner.stream
+    }
+}
+
+/// Extension trait for clients backed by SChannel.
+pub trait ClientContextExt {
+    /// Gets a mutable reference to the underlying SChannel credential builder,
+    /// allowing further configuration.
+    ///
+    /// The builder here will eventually get used to initiate the client
+    /// connection, and it will otherwise be configured to validate the hostname
+    /// given to `handshake` by default.
+    fn schannel_cred(&mut self) -> &mut schannel_cred::Builder;
+
+    /// Gets a mutable reference to the underlying TLS stream builder, allowing
+    /// further configuration.
+    ///
+    /// The builder here will eventually get used to initiate the client
+    /// connection, and it will otherwise be configured to validate the hostname
+    /// given to `handshake` by default.
+    fn tls_stream(&mut self) -> &mut tls_stream::Builder;
+}
+
+impl ClientContextExt for ::ClientContext {
+    fn schannel_cred(&mut self) -> &mut schannel_cred::Builder {
+        &mut self.inner.cred
+    }
+
+    fn tls_stream(&mut self) -> &mut tls_stream::Builder {
+        &mut self.inner.stream
+    }
+}
+
+/// Extension trait for streams backed by SChannel.
+pub trait TlsStreamExt {
+}
+
+impl<S> TlsStreamExt for ::TlsStream<S> {
+}

--- a/src/secure_transport.rs
+++ b/src/secure_transport.rs
@@ -1,0 +1,309 @@
+extern crate security_framework;
+
+use std::mem;
+use std::io::{self, Read, Write, Error, ErrorKind};
+
+use self::security_framework::base::Error as StError;
+use self::security_framework::certificate::SecCertificate;
+use self::security_framework::identity::SecIdentity;
+use self::security_framework::secure_transport as st;
+use self::security_framework::trust::TrustResult;
+use futures::{Poll, Future};
+
+pub struct TlsStream<S> {
+    stream: st::SslStream<S>,
+}
+
+pub struct ServerContext {
+    inner: st::SslContext,
+}
+
+pub struct ClientContext {
+    inner: st::SslContext,
+    certs: Vec<SecCertificate>,
+}
+
+fn cx_new(side: st::ProtocolSide, kind: st::ConnectionType)
+          -> io::Result<st::SslContext> {
+    st::SslContext::new(side, kind).map_err(translate)
+}
+
+impl ClientContext {
+    pub fn new() -> io::Result<ClientContext> {
+        let cx = try!(cx_new(st::ProtocolSide::Client,
+                             st::ConnectionType::Stream));
+        Ok(ClientContext {
+            inner: cx,
+            certs: Vec::new(),
+        })
+    }
+
+    pub fn handshake<S>(self,
+                        domain: &str,
+                        stream: S) -> ClientHandshake<S>
+        where S: Read + Write,
+    {
+        let mut inner = self.inner;
+        let res = inner.set_peer_domain_name(domain)
+                       .map_err(st::HandshakeError::Failure)
+                       .and_then(|()| {
+            inner.handshake(stream)
+        });
+        ClientHandshake {
+            inner: Handshake::new(res, self.certs),
+        }
+    }
+}
+
+impl ServerContext {
+    pub fn handshake<S>(self, stream: S) -> ServerHandshake<S>
+        where S: Read + Write,
+    {
+        ServerHandshake {
+            inner: Handshake::new(self.inner.handshake(stream), Vec::new()),
+        }
+    }
+}
+
+pub struct ClientHandshake<S> {
+    inner: Handshake<S>,
+}
+
+pub struct ServerHandshake<S> {
+    inner: Handshake<S>,
+}
+
+enum Handshake<S> {
+    Error(io::Error),
+    Stream(st::SslStream<S>),
+    Interrupted(st::MidHandshakeSslStream<S>,
+                Vec<SecCertificate>),
+    Empty,
+}
+
+impl<S> Handshake<S> {
+    fn new(res: Result<st::SslStream<S>, st::HandshakeError<S>>,
+           certs: Vec<SecCertificate>)
+           -> Handshake<S> {
+        match res {
+            Ok(s) => {
+                assert!(certs.len() == 0);
+                Handshake::Stream(s)
+            }
+            Err(st::HandshakeError::Failure(e)) => {
+                Handshake::Error(Error::new(ErrorKind::Other, e))
+            }
+            Err(st::HandshakeError::Interrupted(s)) => {
+                Handshake::Interrupted(s, certs)
+            }
+        }
+    }
+}
+
+impl<S> Future for ClientHandshake<S>
+    where S: Read + Write,
+{
+    type Item = TlsStream<S>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<TlsStream<S>, io::Error> {
+        self.inner.poll()
+    }
+}
+
+impl<S> Future for ServerHandshake<S>
+    where S: Read + Write,
+{
+    type Item = TlsStream<S>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<TlsStream<S>, io::Error> {
+        self.inner.poll()
+    }
+}
+
+impl<S> Handshake<S> {
+    fn validate_certs(&self,
+                      stream: &st::MidHandshakeSslStream<S>,
+                      certs: &[SecCertificate]) -> io::Result<()> {
+        // Copied from ClientBuilder in secure_transport.rs
+        //
+        // TODO: this should happen when we get an interrupted error during
+        //       read/write.
+        if certs.len() == 0 || !stream.server_auth_completed() {
+            return Ok(())
+        }
+
+        debug!("handshake auth completed, checking for validity");
+        let mut trust = try!(stream.context().peer_trust().map_err(translate));
+        try!(trust.set_anchor_certificates(&certs).map_err(translate));
+        let trusted = try!(trust.evaluate().map_err(translate));
+        match trusted {
+            TrustResult::Proceed |
+            TrustResult::Unspecified => Ok(()),
+            TrustResult::Invalid |
+            TrustResult::OtherError => {
+                Err(Error::new(ErrorKind::Other, "bad ssl request"))
+            }
+            TrustResult::Deny => {
+                Err(Error::new(ErrorKind::Other, "trust setting denied cert"))
+            }
+            TrustResult::RecoverableTrustFailure |
+            TrustResult::FatalTrustFailure => {
+                Err(Error::new(ErrorKind::Other, "not a trusted certificate"))
+            }
+        }
+    }
+}
+
+impl<S> Future for Handshake<S>
+    where S: Read + Write,
+{
+    type Item = TlsStream<S>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<TlsStream<S>, io::Error> {
+        let (mut stream, certs) = match mem::replace(self, Handshake::Empty) {
+            Handshake::Error(e) => return Poll::Err(e),
+            Handshake::Empty => panic!("can't poll handshake twice"),
+            Handshake::Stream(s) => return Poll::Ok(TlsStream::new(s)),
+            Handshake::Interrupted(s, certs) => (s, certs),
+        };
+
+        loop {
+            if let Err(e) = self.validate_certs(&stream, &certs) {
+                return Poll::Err(e)
+            }
+
+            // TODO: dedup with Handshake::new
+            stream = match stream.handshake() {
+                Ok(s) => return Poll::Ok(TlsStream::new(s)),
+                Err(st::HandshakeError::Failure(e)) => {
+                    return Poll::Err(Error::new(ErrorKind::Other, e))
+                }
+                Err(st::HandshakeError::Interrupted(s)) => s,
+            };
+
+            if stream.would_block() {
+                *self = Handshake::Interrupted(stream, certs);
+                return Poll::NotReady
+            }
+        }
+    }
+}
+
+
+fn translate(err: StError) -> Error {
+    Error::new(ErrorKind::Other, err)
+}
+
+impl<S> TlsStream<S> {
+    fn new(stream: st::SslStream<S>) -> TlsStream<S> {
+        TlsStream {
+            stream: stream,
+        }
+    }
+}
+
+impl<S: Read + Write> Read for TlsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.stream.read(buf)
+    }
+}
+
+impl<S: Read + Write> Write for TlsStream<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.stream.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stream.flush()
+    }
+}
+
+/// Extension trait for servers backed by SecureTransport.
+pub trait ServerContextExt: Sized {
+    /// Creates a new server given the specified `identity` and list of
+    /// certificates supported by the server.
+    ///
+    /// The server will use this identity and certificates for the certificates
+    /// to use when connections are initiated to it.
+    fn new(identity: &SecIdentity,
+           certs: &[SecCertificate]) -> io::Result<Self>;
+
+    /// Gets a mutable reference to the underlying SSL context, allowing further
+    /// configuration.
+    ///
+    /// The SSL context here will eventually get used to initiate the client
+    /// connection, and it will otherwise be configured to validate the hostname
+    /// given to `handshake` by default.
+    fn ssl_context_mut(&mut self) -> &mut st::SslContext;
+}
+
+impl ServerContextExt for ::ServerContext {
+    fn new(identity: &SecIdentity,
+           certs: &[SecCertificate]) -> io::Result<::ServerContext> {
+        let mut cx = try!(cx_new(st::ProtocolSide::Server,
+                                 st::ConnectionType::Stream));
+        try!(cx.set_certificate(&identity, certs)
+               .map_err(translate));
+        Ok(::ServerContext { inner: ServerContext { inner: cx } })
+    }
+
+    fn ssl_context_mut(&mut self) -> &mut st::SslContext {
+        &mut self.inner.inner
+    }
+}
+
+/// Extension trait for clients backed by OpenSSL.
+pub trait ClientContextExt {
+    /// Adds a certificate to be used when validating the trust of the remote
+    /// peer.
+    ///
+    /// The certificates provided will be trusted when communicating with the
+    /// remote host.
+    fn anchor_certificates(&mut self,
+                           certs: &[SecCertificate]) -> io::Result<()>;
+
+    /// Gets a mutable reference to the underlying SSL context, allowing further
+    /// configuration.
+    ///
+    /// The SSL context here will eventually get used to initiate the client
+    /// connection, and it will otherwise be configured to validate the hostname
+    /// given to `handshake` by default.
+    fn ssl_context_mut(&mut self) -> &mut st::SslContext;
+}
+
+impl ClientContextExt for ::ClientContext {
+    fn anchor_certificates(&mut self,
+                           certs: &[SecCertificate]) -> io::Result<()> {
+        try!(self.inner.inner.set_break_on_server_auth(true).map_err(translate));
+        self.inner.certs.extend(certs.iter().cloned());
+        Ok(())
+    }
+
+    fn ssl_context_mut(&mut self) -> &mut st::SslContext {
+        &mut self.inner.inner
+    }
+}
+
+/// Extension trait for streams backed by SecureTransport.
+pub trait TlsStreamExt {
+    /// Gets a shared reference to the underlying SSL context, allowing further
+    /// configuration and/or inspection of the SSL/TLS state.
+    fn ssl_context(&self) -> &st::SslContext;
+
+    /// Gets a mutable reference to the underlying SSL context, allowing further
+    /// configuration and/or inspection of the SSL/TLS state.
+    fn ssl_context_mut(&mut self) -> &mut st::SslContext;
+}
+
+impl<S> TlsStreamExt for ::TlsStream<S> {
+    fn ssl_context(&self) -> &st::SslContext {
+        self.inner.stream.context()
+    }
+
+    fn ssl_context_mut(&mut self) -> &mut st::SslContext {
+        self.inner.stream.context_mut()
+    }
+}

--- a/tests/bad.rs
+++ b/tests/bad.rs
@@ -1,0 +1,129 @@
+extern crate futures;
+extern crate env_logger;
+extern crate tokio_core;
+extern crate tokio_tls;
+
+#[macro_use]
+extern crate cfg_if;
+
+use std::io::Error;
+use std::net::ToSocketAddrs;
+
+use futures::Future;
+use tokio_tls::ClientContext;
+
+macro_rules! t {
+    ($e:expr) => (match $e {
+        Ok(e) => e,
+        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+    })
+}
+
+cfg_if! {
+    if #[cfg(any(feature = "force-openssl",
+                 all(not(target_os = "macos"),
+                     not(target_os = "windows"))))] {
+        extern crate openssl;
+
+        use openssl::ssl;
+
+        fn get(err: &Error) -> &openssl::error::ErrorStack {
+            let err = err.get_ref().unwrap();
+            match *err.downcast_ref::<ssl::error::Error>().unwrap() {
+                ssl::Error::Ssl(ref v) => v,
+                ref e => panic!("not an ssl eror: {:?}", e),
+            }
+        }
+
+        fn verify_failed(err: &Error) {
+            assert!(get(err).errors().iter().any(|e| {
+                e.reason() == "certificate verify failed"
+            }), "bad errors: {:?}", err);
+        }
+
+        use verify_failed as assert_expired_error;
+        use verify_failed as assert_wrong_host;
+        use verify_failed as assert_self_signed;
+        use verify_failed as assert_untrusted_root;
+    } else if #[cfg(target_os = "macos")] {
+        extern crate security_framework;
+
+        use security_framework::base::Error as SfError;
+
+        fn assert_invalid_cert_chain(err: &Error) {
+            let err = err.get_ref().unwrap();
+            let err = err.downcast_ref::<SfError>().unwrap();
+            assert_eq!(err.message().unwrap(), "invalid certificate chain");
+        }
+
+        use assert_invalid_cert_chain as assert_expired_error;
+        use assert_invalid_cert_chain as assert_wrong_host;
+        use assert_invalid_cert_chain as assert_self_signed;
+        use assert_invalid_cert_chain as assert_untrusted_root;
+    } else {
+        extern crate winapi;
+
+        fn assert_expired_error(err: &Error) {
+            let code = err.raw_os_error().unwrap();
+            assert_eq!(code as usize, winapi::CERT_E_EXPIRED as usize);
+        }
+
+        fn assert_wrong_host(err: &Error) {
+            let code = err.raw_os_error().unwrap() as usize;
+            // TODO: this... may be a bug in schannel-rs
+            assert!(code == winapi::CERT_E_CN_NO_MATCH as usize ||
+                    code == winapi::SEC_E_MESSAGE_ALTERED as usize,
+                    "bad error code: {:x}", code);
+        }
+
+        fn assert_self_signed(err: &Error) {
+            let code = err.raw_os_error().unwrap();
+            assert_eq!(code as usize, winapi::CERT_E_UNTRUSTEDROOT as usize);
+        }
+
+        fn assert_untrusted_root(err: &Error) {
+            let code = err.raw_os_error().unwrap();
+            assert_eq!(code as usize, winapi::CERT_E_UNTRUSTEDROOT as usize);
+        }
+    }
+}
+
+fn get_host(host: &'static str) -> Error {
+    drop(env_logger::init());
+
+    let addr = format!("{}:443", host);
+    let addr = t!(addr.to_socket_addrs()).next().unwrap();
+
+    let mut l = t!(tokio_core::Loop::new());
+    let client = l.handle().tcp_connect(&addr);
+    let data = client.and_then(move |socket| {
+        t!(ClientContext::new()).handshake(host, socket)
+    });
+
+    let res = l.run(data);
+    assert!(res.is_err());
+    res.err().unwrap()
+}
+
+#[test]
+fn expired() {
+    assert_expired_error(&get_host("expired.badssl.com"))
+}
+
+// TODO: the OSX builders on Travis apparently fail this tests spuriously?
+//       passes locally though? Seems... bad!
+#[test]
+#[cfg_attr(all(target_os = "macos", feature = "force-openssl"), ignore)]
+fn wrong_host() {
+    assert_wrong_host(&get_host("wrong.host.badssl.com"))
+}
+
+#[test]
+fn self_signed() {
+    assert_self_signed(&get_host("self-signed.badssl.com"))
+}
+
+#[test]
+fn untrusted_root() {
+    assert_untrusted_root(&get_host("untrusted-root.badssl.com"))
+}

--- a/tests/google.rs
+++ b/tests/google.rs
@@ -1,0 +1,106 @@
+extern crate env_logger;
+extern crate futures;
+extern crate tokio_core;
+extern crate tokio_tls;
+
+#[macro_use]
+extern crate cfg_if;
+
+use std::io::Error;
+use std::net::ToSocketAddrs;
+
+use futures::Future;
+use tokio_core::io::{flush, read_to_end, write_all};
+use tokio_tls::ClientContext;
+
+macro_rules! t {
+    ($e:expr) => (match $e {
+        Ok(e) => e,
+        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+    })
+}
+
+cfg_if! {
+    if #[cfg(any(feature = "force-openssl",
+                 all(not(target_os = "macos"),
+                     not(target_os = "windows"))))] {
+        extern crate openssl;
+
+        use openssl::ssl as ossl;
+
+        fn assert_bad_hostname_error(err: &Error) {
+            let err = err.get_ref().unwrap();
+            let errs = match *err.downcast_ref::<ossl::Error>().unwrap() {
+                ossl::Error::Ssl(ref v) => v,
+                ref e => panic!("not an ssl eror: {:?}", e),
+            };
+            assert!(errs.errors().iter().any(|e| {
+                e.reason() == "certificate verify failed"
+            }), "bad errors: {:?}", errs);
+        }
+    } else if #[cfg(target_os = "macos")] {
+        extern crate security_framework;
+
+        use security_framework::base::Error as SfError;
+
+        fn assert_bad_hostname_error(err: &Error) {
+            let err = err.get_ref().unwrap();
+            let err = err.downcast_ref::<SfError>().unwrap();
+            assert_eq!(err.message().unwrap(), "invalid certificate chain");
+        }
+    } else {
+        extern crate winapi;
+
+        fn assert_bad_hostname_error(err: &Error) {
+            let code = err.raw_os_error().unwrap();
+            assert_eq!(code as usize, winapi::CERT_E_CN_NO_MATCH as usize);
+        }
+    }
+}
+
+#[test]
+fn fetch_google() {
+    drop(env_logger::init());
+
+    // First up, resolve google.com
+    let addr = t!("google.com:443".to_socket_addrs()).next().unwrap();
+
+    // Create an event loop and connect a socket to our resolved address.c
+    let mut l = t!(tokio_core::Loop::new());
+    let client = l.handle().tcp_connect(&addr);
+
+    // Send off the request by first negotiating an SSL handshake, then writing
+    // of our request, then flushing, then finally read off the response.
+    let data = client.and_then(move |socket| {
+        t!(ClientContext::new()).handshake("google.com", socket)
+    }).and_then(|socket| {
+        write_all(socket, b"GET / HTTP/1.0\r\n\r\n")
+    }).and_then(|(socket, _)| {
+        flush(socket)
+    }).and_then(|socket| {
+        read_to_end(socket, Vec::new())
+    });
+
+    let (_, data) = t!(l.run(data));
+    assert!(data.starts_with(b"HTTP/1.0 200 OK"));
+    assert!(data.ends_with(b"</html>"));
+}
+
+// see comment in bad.rs for ignore reason
+#[cfg_attr(all(target_os = "macos", feature = "force-openssl"), ignore)]
+#[test]
+fn wrong_hostname_error() {
+    drop(env_logger::init());
+
+    let addr = t!("google.com:443".to_socket_addrs()).next().unwrap();
+
+    let mut l = t!(tokio_core::Loop::new());
+    let client = l.handle().tcp_connect(&addr);
+    let data = client.and_then(move |socket| {
+        t!(ClientContext::new()).handshake("rust-lang.org", socket)
+    });
+
+    let res = l.run(data);
+    assert!(res.is_err());
+    assert_bad_hostname_error(&res.err().unwrap());
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,0 +1,543 @@
+extern crate env_logger;
+extern crate futures;
+extern crate tokio_core;
+extern crate tokio_tls;
+
+#[macro_use]
+extern crate cfg_if;
+
+use std::io::{self, Read, Write};
+
+use futures::Future;
+use futures::stream::Stream;
+use tokio_core::io::{read_to_end, copy};
+use tokio_tls::{ServerContext, ClientContext};
+
+macro_rules! t {
+    ($e:expr) => (match $e {
+        Ok(e) => e,
+        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+    })
+}
+
+cfg_if! {
+    if #[cfg(any(feature = "force-openssl",
+                 all(not(target_os = "macos"),
+                     not(target_os = "windows"))))] {
+        extern crate openssl;
+
+        use std::fs::File;
+        use std::env;
+        use std::sync::{Once, ONCE_INIT};
+
+        use openssl::crypto::hash::Type;
+        use openssl::crypto::pkey::PKey;
+        use openssl::crypto::rsa::RSA;
+        use openssl::x509::{X509Generator, X509};
+
+        use tokio_tls::backend::openssl::ServerContextExt;
+        use tokio_tls::backend::openssl::ClientContextExt;
+
+        fn server_cx() -> io::Result<ServerContext> {
+            let (cert, key) = keys();
+            ServerContext::new(cert, key)
+        }
+
+        fn configure_client(cx: &mut ClientContext) {
+            // Unfortunately looks like the only way to configure this is
+            // `set_CA_file` file on the client side so we have to actually
+            // emit the certificate to a file. Do so next to our own binary
+            // which is likely ephemeral as well.
+            let path = t!(env::current_exe());
+            let path = path.parent().unwrap().join("custom.crt");
+            static INIT: Once = ONCE_INIT;
+            INIT.call_once(|| {
+                let pem = keys().0.to_pem().unwrap();
+                t!(t!(File::create(&path)).write_all(&pem));
+            });
+            let ssl = cx.ssl_context_mut();
+            t!(ssl.set_CA_file(&path));
+        }
+
+        // Generates a new key on the fly to be used for the entire suite of
+        // tests here.
+        fn keys() -> (&'static X509, &'static PKey) {
+            static INIT: Once = ONCE_INIT;
+            static mut CERT: *mut X509 = 0 as *mut _;
+            static mut KEY: *mut PKey = 0 as *mut _;
+
+            unsafe {
+                INIT.call_once(|| {
+                    let rsa = RSA::generate(1024).unwrap();
+                    let pkey = PKey::from_rsa(rsa).unwrap();
+                    let gen = X509Generator::new()
+                                .set_valid_period(1)
+                                .add_name("CN".to_owned(), "localhost".to_owned())
+                                .set_sign_hash(Type::SHA256);
+                    let cert = gen.sign(&pkey).unwrap();
+
+                    CERT = Box::into_raw(Box::new(cert));
+                    KEY = Box::into_raw(Box::new(pkey));
+                });
+
+                (&*CERT, &*KEY)
+            }
+        }
+    } else if #[cfg(target_os = "macos")] {
+        extern crate security_framework;
+
+        use std::env;
+        use std::fs::{self, File};
+        use std::path::PathBuf;
+        use std::process::Command;
+        use std::sync::{Once, ONCE_INIT};
+
+        use security_framework::certificate::SecCertificate;
+        use security_framework::import_export::Pkcs12ImportOptions;
+        use security_framework::keychain::SecKeychain;
+        use security_framework::os::macos::import_export::Pkcs12ImportOptionsExt;
+        use security_framework::os::macos::keychain::CreateOptions;
+        use security_framework::os::macos::keychain::SecKeychainExt;
+
+        use tokio_tls::backend::secure_transport::ServerContextExt;
+        use tokio_tls::backend::secure_transport::ClientContextExt;
+
+        fn server_cx() -> io::Result<ServerContext> {
+            let (keychain, keyfile, _) = keys();
+            let mut key = Vec::new();
+            t!(t!(File::open(&keyfile)).read_to_end(&mut key));
+            let mut keychain = t!(SecKeychain::open(&keychain));
+            t!(keychain.unlock(Some("test")));
+
+            let mut options = Pkcs12ImportOptions::new();
+            Pkcs12ImportOptionsExt::keychain(&mut options, keychain);
+            let identities = t!(options.passphrase("foobar")
+                                       .import(&key));
+            assert!(identities.len() == 1);
+            ServerContext::new(&identities[0].identity, &identities[0].cert_chain)
+        }
+
+        fn configure_client(cx: &mut ClientContext) {
+            let (_, _, certfile) = keys();
+            let mut der = Vec::new();
+            t!(t!(File::open(&certfile)).read_to_end(&mut der));
+            let cert = SecCertificate::from_der(&der).unwrap();
+            t!(cx.anchor_certificates(&[cert]));
+        }
+
+        // Like OpenSSL we generate certificates on the fly, but for OSX we
+        // also have to put them into a specific keychain. We put both the
+        // certificates and the keychain next to our binary.
+        //
+        // Right now I don't know of a way to programmatically create a
+        // self-signed certificate, so we just fork out to the `openssl` binary.
+        fn keys() -> (PathBuf, PathBuf, PathBuf) {
+            static INIT: Once = ONCE_INIT;
+
+            let path = t!(env::current_exe());
+            let path = path.parent().unwrap();
+            let keychain = path.join("test.keychain");
+            let keyfile = path.join("test.p12");
+            let certfile = path.join("test.der");
+
+            INIT.call_once(|| {
+                let _ = fs::remove_file(&keychain);
+                let _ = fs::remove_file(&keyfile);
+                let _ = fs::remove_file(&certfile);
+                t!(CreateOptions::new()
+                    .password("test")
+                    .create(&keychain));
+
+                let subj = "/C=US/ST=Denial/L=Sprintfield/O=Dis/CN=localhost";
+                let output = t!(Command::new("openssl")
+                                        .arg("req")
+                                        .arg("-nodes")
+                                        .arg("-new")
+                                        .arg("-x509")
+                                        .arg("-subj").arg(subj)
+                                        .arg("-out").arg(&certfile)
+                                        .arg("-keyout").arg(&keyfile)
+                                        .output());
+                assert!(output.status.success());
+
+                let output = t!(Command::new("openssl")
+                                        .arg("pkcs12")
+                                        .arg("-export")
+                                        .arg("-nodes")
+                                        .arg("-inkey").arg(&keyfile)
+                                        .arg("-in").arg(&certfile)
+                                        .arg("-password").arg("pass:foobar")
+                                        .output());
+                assert!(output.status.success());
+                t!(t!(File::create(&keyfile)).write_all(&output.stdout));
+
+                let output = t!(Command::new("openssl")
+                                        .arg("x509")
+                                        .arg("-outform").arg("der")
+                                        .arg("-in").arg(&certfile)
+                                        .output());
+                assert!(output.status.success());
+                t!(t!(File::create(&certfile)).write_all(&output.stdout));
+            });
+
+            (keychain, keyfile, certfile)
+        }
+    } else {
+        extern crate advapi32;
+        extern crate crypt32;
+        extern crate schannel;
+        extern crate winapi;
+        extern crate kernel32;
+
+        use std::env;
+        use std::io::Error;
+        use std::mem;
+        use std::ptr;
+        use std::sync::{Once, ONCE_INIT};
+
+        use schannel::cert_context::CertContext;
+        use schannel::cert_store::{CertStore, CertAdd};
+
+        use tokio_tls::backend::schannel::ServerContextExt;
+
+        const FRIENDLY_NAME: &'static str = "tokio-tls localhost testing cert";
+
+        fn server_cx() -> io::Result<ServerContext> {
+            let mut cx = ServerContext::new();
+            cx.schannel_cred().cert(localhost_cert());
+            Ok(cx)
+        }
+
+        fn configure_client(cx: &mut ClientContext) {
+            drop(cx);
+        }
+
+        // ====================================================================
+        // Magic!
+        //
+        // Lots of magic is happening here to wrangle certificates for running
+        // these tests on Windows. For more information see the test suite
+        // in the schannel-rs crate as this is just coyping that.
+        //
+        // The general gist of this though is that the only way to add custom
+        // trusted certificates is to add it to the system store of trust. To
+        // do that we go through the whole rigamarole here to generate a new
+        // self-signed certificate and then insert that into the system store.
+        //
+        // This generates some dialogs, so we print what we're doing sometimes,
+        // and otherwise we just manage the ephemeral certificates. Because
+        // they're in the system store we always ensure that they're only valid
+        // for a small period of time (e.g. 1 day).
+
+        fn localhost_cert() -> CertContext {
+            static INIT: Once = ONCE_INIT;
+            INIT.call_once(|| {
+                for cert in local_root_store().certs() {
+                    let name = match cert.friendly_name() {
+                        Ok(name) => name,
+                        Err(_) => continue,
+                    };
+                    if name != FRIENDLY_NAME {
+                        continue
+                    }
+                    if !cert.is_time_valid().unwrap() {
+                        io::stdout().write_all(br#"
+
+The tokio-tls test suite is about to delete an old copy of one of its
+certificates from your root trust store. This certificate was only valid for one
+day and it is no longer needed. The host should be "localhost" and the
+description should mention "tokio-tls".
+
+        "#).unwrap();
+                        cert.delete().unwrap();
+                    } else {
+                        return
+                    }
+                }
+
+                install_certificate().unwrap();
+            });
+
+            for cert in local_root_store().certs() {
+                let name = match cert.friendly_name() {
+                    Ok(name) => name,
+                    Err(_) => continue,
+                };
+                if name == FRIENDLY_NAME {
+                    return cert
+                }
+            }
+
+            panic!("couldn't find a cert");
+        }
+
+        fn local_root_store() -> CertStore {
+            if env::var("APPVEYOR").is_ok() {
+                CertStore::open_local_machine("Root").unwrap()
+            } else {
+                CertStore::open_current_user("Root").unwrap()
+            }
+        }
+
+        fn install_certificate() -> io::Result<CertContext> {
+            unsafe {
+                let mut provider = 0;
+                let mut hkey = 0;
+
+                let mut buffer = "tokio-tls test suite".encode_utf16()
+                                                         .chain(Some(0))
+                                                         .collect::<Vec<_>>();
+                let res = advapi32::CryptAcquireContextW(&mut provider,
+                                                         buffer.as_ptr(),
+                                                         ptr::null_mut(),
+                                                         winapi::PROV_RSA_FULL,
+                                                         winapi::CRYPT_MACHINE_KEYSET);
+                if res != winapi::TRUE {
+                    // create a new key container (since it does not exist)
+                    let res = advapi32::CryptAcquireContextW(&mut provider,
+                                                             buffer.as_ptr(),
+                                                             ptr::null_mut(),
+                                                             winapi::PROV_RSA_FULL,
+                                                             winapi::CRYPT_NEWKEYSET | winapi::CRYPT_MACHINE_KEYSET);
+                    if res != winapi::TRUE {
+                        return Err(Error::last_os_error())
+                    }
+                }
+
+                // create a new keypair (RSA-2048)
+                let res = advapi32::CryptGenKey(provider,
+                                                winapi::AT_SIGNATURE,
+                                                0x0800<<16 | winapi::CRYPT_EXPORTABLE,
+                                                &mut hkey);
+                if res != winapi::TRUE {
+                    return Err(Error::last_os_error());
+                }
+
+                // start creating the certificate
+                let name = "CN=localhost,O=tokio-tls,OU=tokio-tls,\
+                            G=tokio_tls".encode_utf16()
+                                          .chain(Some(0))
+                                          .collect::<Vec<_>>();
+                let mut cname_buffer: [winapi::WCHAR; winapi::UNLEN as usize + 1] = mem::zeroed();
+                let mut cname_len = cname_buffer.len() as winapi::DWORD;
+                let res = crypt32::CertStrToNameW(winapi::X509_ASN_ENCODING,
+                                                  name.as_ptr(),
+                                                  winapi::CERT_X500_NAME_STR,
+                                                  ptr::null_mut(),
+                                                  cname_buffer.as_mut_ptr() as *mut u8,
+                                                  &mut cname_len,
+                                                  ptr::null_mut());
+                if res != winapi::TRUE {
+                    return Err(Error::last_os_error());
+                }
+
+                let mut subject_issuer = winapi::CERT_NAME_BLOB {
+                    cbData: cname_len,
+                    pbData: cname_buffer.as_ptr() as *mut u8,
+                };
+                let mut key_provider = winapi::CRYPT_KEY_PROV_INFO {
+                    pwszContainerName: buffer.as_mut_ptr(),
+                    pwszProvName: ptr::null_mut(),
+                    dwProvType: winapi::PROV_RSA_FULL,
+                    dwFlags: winapi::CRYPT_MACHINE_KEYSET,
+                    cProvParam: 0,
+                    rgProvParam: ptr::null_mut(),
+                    dwKeySpec: winapi::AT_SIGNATURE,
+                };
+                let mut sig_algorithm = winapi::CRYPT_ALGORITHM_IDENTIFIER {
+                    pszObjId: winapi::szOID_RSA_SHA256RSA.as_ptr() as *mut _,
+                    Parameters: mem::zeroed(),
+                };
+                let mut expiration_date: winapi::SYSTEMTIME = mem::zeroed();
+                kernel32::GetSystemTime(&mut expiration_date);
+                let mut file_time: winapi::FILETIME = mem::zeroed();
+                let res = kernel32::SystemTimeToFileTime(&mut expiration_date,
+                                                         &mut file_time);
+                if res != winapi::TRUE {
+                    return Err(Error::last_os_error());
+                }
+                let mut timestamp: u64 = file_time.dwLowDateTime as u64 |
+                                         (file_time.dwHighDateTime as u64) << 32;
+                // one day, timestamp unit is in 100 nanosecond intervals
+                timestamp += (1E9 as u64) / 100 * (60 * 60 * 24);
+                file_time.dwLowDateTime = timestamp as u32;
+                file_time.dwHighDateTime = (timestamp >> 32) as u32;
+                let res = kernel32::FileTimeToSystemTime(&file_time,
+                                                         &mut expiration_date);
+                if res != winapi::TRUE {
+                    return Err(Error::last_os_error());
+                }
+
+                // create a self signed certificate
+                let cert_context = crypt32::CertCreateSelfSignCertificate(
+                        0 as winapi::ULONG_PTR,
+                        &mut subject_issuer,
+                        0,
+                        &mut key_provider,
+                        &mut sig_algorithm,
+                        ptr::null_mut(),
+                        &mut expiration_date,
+                        ptr::null_mut());
+                if cert_context.is_null() {
+                    return Err(Error::last_os_error());
+                }
+
+                // TODO: this is.. a terrible hack. Right now `schannel`
+                //       doesn't provide a public method to go from a raw
+                //       cert context pointer to the `CertContext` structure it
+                //       has, so we just fake it here with a transmute. This'll
+                //       probably break at some point, but hopefully by then
+                //       it'll have a method to do this!
+                struct MyCertContext<T>(T);
+                impl<T> Drop for MyCertContext<T> {
+                    fn drop(&mut self) {}
+                }
+
+                let cert_context = MyCertContext(cert_context);
+                let cert_context: CertContext = mem::transmute(cert_context);
+
+                try!(cert_context.set_friendly_name(FRIENDLY_NAME));
+
+                // install the certificate to the machine's local store
+                io::stdout().write_all(br#"
+
+The tokio-tls test suite is about to add a certificate to your set of root
+and trusted certificates. This certificate should be for the domain "localhost"
+with the description related to "tokio-tls". This certificate is only valid
+for one day and will be automatically deleted if you re-run the tokio-tls
+test suite later.
+
+        "#).unwrap();
+                try!(local_root_store().add_cert(&cert_context,
+                                                 CertAdd::ReplaceExisting));
+                Ok(cert_context)
+            }
+        }
+    }
+}
+
+fn client_cx() -> io::Result<ClientContext> {
+    let mut cx = try!(ClientContext::new());
+    configure_client(&mut cx);
+    Ok(cx)
+}
+
+const AMT: u64 = 128 * 1024;
+
+#[test]
+fn client_to_server() {
+    drop(env_logger::init());
+    let mut l = t!(tokio_core::Loop::new());
+
+    // Create a server listening on a port, then figure out what that port is
+    let srv = l.handle().tcp_listen(&"127.0.0.1:0".parse().unwrap());
+    let srv = t!(l.run(srv));
+    let addr = t!(srv.local_addr());
+
+    // Create a future to accept one socket, connect the ssl stream, and then
+    // read all the data from it.
+    let socket = srv.incoming().take(1).collect();
+    let received = socket.map(|mut socket| {
+        socket.remove(0).0
+    }).and_then(move |socket| {
+        t!(server_cx()).handshake(socket)
+    }).and_then(|socket| {
+        read_to_end(socket, Vec::new())
+    });
+
+    // Create a future to connect to our server, connect the ssl stream, and
+    // then write a bunch of data to it.
+    let client = l.handle().tcp_connect(&addr);
+    let sent = client.and_then(move |socket| {
+        t!(client_cx()).handshake("localhost", socket)
+    }).and_then(|socket| {
+        copy(io::repeat(9).take(AMT), socket)
+    });
+
+    // Finally, run everything!
+    let (amt, (_, data)) = t!(l.run(sent.join(received)));
+    assert_eq!(amt, AMT);
+    assert!(data == vec![9; amt as usize]);
+}
+
+#[test]
+fn server_to_client() {
+    drop(env_logger::init());
+    let mut l = t!(tokio_core::Loop::new());
+
+    // Create a server listening on a port, then figure out what that port is
+    let srv = l.handle().tcp_listen(&"127.0.0.1:0".parse().unwrap());
+    let srv = t!(l.run(srv));
+    let addr = t!(srv.local_addr());
+
+    let socket = srv.incoming().take(1).collect();
+    let sent = socket.map(|mut socket| {
+        socket.remove(0).0
+    }).and_then(move |socket| {
+        t!(server_cx()).handshake(socket)
+    }).and_then(|socket| {
+        copy(io::repeat(9).take(AMT), socket)
+    });
+
+    let client = l.handle().tcp_connect(&addr);
+    let received = client.and_then(move |socket| {
+        t!(client_cx()).handshake("localhost", socket)
+    }).and_then(|socket| {
+        read_to_end(socket, Vec::new())
+    });
+
+    // Finally, run everything!
+    let (amt, (_, data)) = t!(l.run(sent.join(received)));
+    assert_eq!(amt, AMT);
+    assert!(data == vec![9; amt as usize]);
+}
+
+struct OneByte<S> {
+    inner: S,
+}
+
+impl<S: Read> Read for OneByte<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(&mut buf[..1])
+    }
+}
+
+impl<S: Write> Write for OneByte<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(&buf[..1])
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[test]
+fn one_byte_at_a_time() {
+    drop(env_logger::init());
+    let mut l = t!(tokio_core::Loop::new());
+
+    let srv = l.handle().tcp_listen(&"127.0.0.1:0".parse().unwrap());
+    let srv = t!(l.run(srv));
+    let addr = t!(srv.local_addr());
+
+    let socket = srv.incoming().take(1).collect();
+    let sent = socket.map(|mut socket| {
+        socket.remove(0).0
+    }).and_then(move |socket| {
+        t!(server_cx()).handshake(OneByte { inner: socket })
+    }).and_then(|socket| {
+        copy(io::repeat(9).take(AMT), socket)
+    });
+
+    let client = l.handle().tcp_connect(&addr);
+    let received = client.and_then(move |socket| {
+        t!(client_cx()).handshake("localhost", OneByte { inner: socket })
+    }).and_then(|socket| {
+        read_to_end(socket, Vec::new())
+    });
+
+    let (amt, (_, data)) = t!(l.run(sent.join(received)));
+    assert_eq!(amt, AMT);
+    assert!(data == vec![9; amt as usize]);
+}


### PR DESCRIPTION
This is an import of the [futures-tls] crate which provides cross-platform
bindings in addition to OpenSSL, and is one day targeted at being built on the
[native-tls] crate as well.

Otherwise the APIs are quite similar, with the only difference being that a
handshake returns a future representing the completed portion of the connection.