### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,14 @@ log = "0.3"
 tokio-core = "0.1"
 
 # Optional dependency that can be enabled with the `force-openssl` feature
-openssl = { version = "0.8", optional = true }
-openssl-verify = { version = "0.2", optional = true }
+openssl = { version = "0.9", optional = true }
 
 # Optional dependency to use `rustls` as a backend, enabled with `force-rustls`
 rustls = { version = "0.1.2", optional = true }
 webpki-roots = { version = "0.2", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
-openssl = "0.8"
-openssl-verify = "0.2"
+openssl = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "0.1"
@@ -48,5 +46,5 @@ webpki = "0.3"
 untrusted = "0.3"
 
 [features]
-force-openssl = ["openssl", "openssl-verify"]
+force-openssl = ["openssl"]
 force-rustls = ["rustls", "webpki-roots"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ tokio-core = "0.1"
 openssl = { version = "0.9", optional = true }
 
 # Optional dependency to use `rustls` as a backend, enabled with `force-rustls`
-rustls = { version = "0.1.2", optional = true }
-webpki-roots = { version = "0.2", optional = true }
+rustls = { version = "0.5", optional = true }
+webpki-roots = { version = "0.5", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 openssl = "0.9"

--- a/tests/bad.rs
+++ b/tests/bad.rs
@@ -52,7 +52,7 @@ cfg_if! {
 
         fn get(err: &Error) -> &openssl::error::ErrorStack {
             let err = err.get_ref().unwrap();
-            match *err.downcast_ref::<ssl::error::Error>().unwrap() {
+            match *err.downcast_ref::<ssl::Error>().unwrap() {
                 ssl::Error::Ssl(ref v) => v,
                 ref e => panic!("not an ssl eror: {:?}", e),
             }
@@ -60,7 +60,7 @@ cfg_if! {
 
         fn verify_failed(err: &Error) {
             assert!(get(err).errors().iter().any(|e| {
-                e.reason() == "certificate verify failed"
+                e.reason() == Some("certificate verify failed")
             }), "bad errors: {:?}", err);
         }
 

--- a/tests/google.rs
+++ b/tests/google.rs
@@ -42,7 +42,7 @@ cfg_if! {
                 ref e => panic!("not an ssl eror: {:?}", e),
             };
             assert!(errs.errors().iter().any(|e| {
-                e.reason() == "certificate verify failed"
+                e.reason() == Some("certificate verify failed")
             }), "bad errors: {:?}", errs);
         }
     } else if #[cfg(target_os = "macos")] {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -130,9 +130,9 @@ cfg_if! {
         use std::env;
         use std::sync::{Once, ONCE_INIT};
 
-        use openssl::crypto::hash::Type;
-        use openssl::crypto::pkey::PKey;
-        use openssl::crypto::rsa::RSA;
+        use openssl::hash::MessageDigest;
+        use openssl::pkey::PKey;
+        use openssl::rsa::Rsa;
         use openssl::x509::{X509Generator, X509};
 
         use tokio_tls::backend::openssl::ServerContextExt;
@@ -156,7 +156,7 @@ cfg_if! {
                 t!(t!(File::create(&path)).write_all(&pem));
             });
             let ssl = cx.ssl_context_mut();
-            t!(ssl.set_CA_file(&path));
+            t!(ssl.set_ca_file(&path));
         }
 
         // Generates a new key on the fly to be used for the entire suite of
@@ -168,12 +168,12 @@ cfg_if! {
 
             unsafe {
                 INIT.call_once(|| {
-                    let rsa = RSA::generate(1024).unwrap();
+                    let rsa = Rsa::generate(1024).unwrap();
                     let pkey = PKey::from_rsa(rsa).unwrap();
                     let gen = X509Generator::new()
                                 .set_valid_period(1)
                                 .add_name("CN".to_owned(), "localhost".to_owned())
-                                .set_sign_hash(Type::SHA256);
+                                .set_sign_hash(MessageDigest::sha256());
                     let cert = gen.sign(&pkey).unwrap();
 
                     CERT = Box::into_raw(Box::new(cert));


### PR DESCRIPTION
The biggest change is the use of https://docs.rs/openssl/0.9.2/openssl/ssl/struct.SslAcceptor.html and https://docs.rs/openssl/0.9.2/openssl/ssl/struct.SslConnector.html.