### PR TITLE
Implement the Debug trait for TlsStreams.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,9 @@ impl<S: Io> Io for TlsStream<S> {
     }
 }
 
-impl<S: Io + std::fmt::Debug> Debug for TlsStream<S> {
+impl<S: Io + std::fmt::Debug> Debug for TlsStream<S>
+    where imp::TlsStream<S>: std::fmt::Debug,
+{
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
         self.inner.fmt(fmt)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate log;
 extern crate tokio_core;
 
 use std::io::{self, Read, Write};
+use std::fmt::{Debug};
 
 use futures::{Poll, Future, Async};
 use tokio_core::io::Io;
@@ -236,5 +237,11 @@ impl<S: Io> Io for TlsStream<S> {
 
     fn poll_write(&mut self) -> Async<()> {
         self.inner.poll_write()
+    }
+}
+
+impl<S: Io + std::fmt::Debug> Debug for TlsStream<S> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+        self.inner.fmt(fmt)
     }
 }

--- a/src/openssl.rs
+++ b/src/openssl.rs
@@ -4,6 +4,7 @@ extern crate futures;
 
 use std::io::{self, Read, Write, Error, ErrorKind};
 use std::mem;
+use std::fmt::{self, Debug};
 
 use self::openssl::crypto::pkey::PKey;
 use self::openssl::ssl::{SSL_OP_NO_SSLV2, SSL_OP_NO_SSLV3, SSL_OP_NO_COMPRESSION};
@@ -199,6 +200,12 @@ impl<S: Io> Write for TlsStream<S> {
 
 impl<S: Io> Io for TlsStream<S> {
     // TODO: more fine-tuned poll_read/poll_write
+}
+
+impl<S: Io + fmt::Debug> Debug for TlsStream<S> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.inner.fmt(fmt)
+    }
 }
 
 /// Extension trait for servers backed by OpenSSL.

--- a/src/rustls.rs
+++ b/src/rustls.rs
@@ -2,6 +2,7 @@ extern crate futures;
 extern crate rustls;
 extern crate webpki_roots;
 
+use std::fmt;
 use std::io::{self, Read, Write, Error, ErrorKind};
 use std::mem;
 use std::sync::Arc;
@@ -221,6 +222,21 @@ impl<S: Io> Write for TlsStream<S> {
             try!(self.session.write_tls(&mut self.inner));
         }
         Ok(())
+    }
+}
+
+impl<S: Io + fmt::Debug> fmt::Debug for TlsStream<S> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let wants_read = self.session.wants_read();
+        let wants_write = self.session.wants_write();
+        let is_handshaking = self.session.is_handshaking();
+        fmt.debug_struct("TlsStream")
+            .field("inner", &self.inner)
+            .field("eof", &self.eof)
+            .field("wants_read", &wants_read)
+            .field("wants_write", &wants_write)
+            .field("is_handshaking", &is_handshaking)
+            .finish()
     }
 }
 


### PR DESCRIPTION
It can be useful to be able to derive Debug for things that include TlsStreams. This is a minimal Debug impl (just forwards to the underlying stream).